### PR TITLE
Reference AWS SDK v1.11.44

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext.teamcityDir = hasProperty('teamcity.dir') ? property('teamcity.dir') : "$roo
 ext.teamcityDataDir = "$rootDir/teamcity/data"
 ext.teamcityJavaHome = System.properties['java.home']
 
-ext.awsSDKVersion = hasProperty('aws.sdk.version') ? property('aws.sdk.version') : '1.11.4'
+ext.awsSDKVersion = hasProperty('aws.sdk.version') ? property('aws.sdk.version') : '1.11.44'
 
 ext.javaVersion = hasProperty('plugin.java.version') ? property('plugin.java.version') : '1.7'
 


### PR DESCRIPTION
build: update AWS SDK reference to newer version

update build.gradle file to reference AWS SDK v1.11.44 instead of
v1.11.4 so that "US-East-2" region is available.