### PR TITLE
Updated the regular expression on the object name validator to allow …

### DIFF
--- a/aws-elasticbeanstalk-common/src/main/java/jetbrains/buildServer/runner/elasticbeanstalk/ParametersValidator.java
+++ b/aws-elasticbeanstalk-common/src/main/java/jetbrains/buildServer/runner/elasticbeanstalk/ParametersValidator.java
@@ -114,7 +114,7 @@ final class ParametersValidator {
 
   private static void validateS3Key(@NotNull Map<String, String> invalids, @NotNull String param, @NotNull String key, @NotNull String name, boolean runtime) {
     if (!isReference(param, runtime)) {
-      if (!param.matches("[a-zA-Z_0-9!\\-\\.*'()/]*")) {
+      if (!param.matches("[a-zA-Z_0-9!\\-\\.*'()/,:-]*")) {
         invalids.put(key, name + " must contain only safe characters");
       }
     }


### PR DESCRIPTION
…the presence of a semicolon (:), this is a legitimate character in an AWS S3 object key.


Tested with a full EB deployment and now works great.