### PR TITLE
Log output clean up.

### DIFF
--- a/aws-elasticbeanstalk-agent/src/main/java/jetbrains/buildServer/runner/elasticbeanstalk/LoggingDeploymentListener.java
+++ b/aws-elasticbeanstalk-agent/src/main/java/jetbrains/buildServer/runner/elasticbeanstalk/LoggingDeploymentListener.java
@@ -54,31 +54,30 @@ class LoggingDeploymentListener extends AWSClient.Listener {
   void createVersionStarted(@NotNull String applicationName, @NotNull String versionLabel,
                             @NotNull String s3BucketName, @NotNull String s3ObjectKey) {
     open(CREATE_VERSION);
-    log(String.format("Creating application %s version %s with bucket %s and key %s", applicationName, versionLabel, s3BucketName, s3ObjectKey));
+    log(String.format("Creating application %s version %s with bucket %s and key %s.", applicationName, versionLabel, s3BucketName, s3ObjectKey));
   }
 
   @Override
   void createVersionFinished(@NotNull String applicationName, @NotNull String versionLabel,
                              @NotNull String s3BucketName, @NotNull String s3ObjectKey) {
-    log(String.format("Created application %s version %s with bucket %s and key %s", applicationName, versionLabel, s3BucketName, s3ObjectKey));
+    log(String.format("Created application %s version %s with bucket %s and key %s.", applicationName, versionLabel, s3BucketName, s3ObjectKey));
     close(CREATE_VERSION);
   }
 
   @Override
   void deploymentStarted(@NotNull String applicationName, @NotNull String environmentName, @NotNull String versionLabel) {
     open(UPDATE_ENVIRONMENT);
-    log(String.format("Started deployment of application %s version %s to %s", applicationName, versionLabel, environmentName));
+    log(String.format("Started deployment of application %s version %s to %s.", applicationName, versionLabel, environmentName));
   }
 
   @Override
   void deploymentWaitStarted(@NotNull String environmentName) {
-    log("Waiting for deployment finish");
-    log(String.format("Waiting for deployment on environment %s", environmentName));
+    log("Waiting for deployment finish.");
   }
 
   @Override
   void deploymentInProgress(@NotNull String environmentName) {
-    progress(String.format("Waiting for deployment on environment %s", environmentName));
+    progress(String.format("Waiting for deployment on environment %s.", environmentName));
   }
 
   @Override
@@ -113,8 +112,8 @@ class LoggingDeploymentListener extends AWSClient.Listener {
   }
 
   @Override
-  void deploymentSucceeded(@NotNull String versionLabel) {
-    String message = String.format("Version %s was deployed successfully", versionLabel);
+  void deploymentSucceeded(@NotNull String environmentName, @NotNull String versionLabel) {
+    String message = String.format("Version %s was deployed to %s successfully.", versionLabel, environmentName);
     log(message);
     statusText(message);
     close(UPDATE_ENVIRONMENT);

--- a/aws-elasticbeanstalk-agent/src/test/java/jetbrains.buildServer.runner.elasticbeanstalk/LoggingDeploymentListenerTest.java
+++ b/aws-elasticbeanstalk-agent/src/test/java/jetbrains.buildServer.runner.elasticbeanstalk/LoggingDeploymentListenerTest.java
@@ -59,35 +59,34 @@ public class LoggingDeploymentListenerTest extends LoggingTestCase {
 
     listener.deploymentInProgress(FAKE_ENV_NAME);
 
-    listener.deploymentSucceeded(FAKE_APP_VERSION);
+    listener.deploymentSucceeded(FAKE_ENV_NAME, FAKE_APP_VERSION);
 
     assertLog(
       "OPEN " + LoggingDeploymentListener.CREATE_VERSION,
-      "LOG Creating application " + FAKE_APP_NAME + " version " + FAKE_APP_VERSION + " with bucket " + bucketName + " and key " + key,
-      "LOG Created application " + FAKE_APP_NAME + " version " + FAKE_APP_VERSION + " with bucket " + bucketName + " and key " + key,
+      String.format("LOG Creating application %s version %s with bucket %s and key %s.", FAKE_APP_NAME, FAKE_APP_VERSION, bucketName, key),
+      String.format("LOG Created application %s version %s with bucket %s and key %s.", FAKE_APP_NAME, FAKE_APP_VERSION, bucketName, key),
       "CLOSE " + LoggingDeploymentListener.CREATE_VERSION,
       "OPEN " + LoggingDeploymentListener.UPDATE_ENVIRONMENT,
-      "LOG Started deployment of application " + FAKE_APP_NAME + " version " + FAKE_APP_VERSION + " to " + FAKE_ENV_NAME,
-      "LOG Waiting for deployment finish",
-      "LOG Waiting for deployment on environment " + FAKE_ENV_NAME,
-      "PROGRESS Waiting for deployment on environment " + FAKE_ENV_NAME,
-      "LOG Version " + FAKE_APP_VERSION + " was deployed successfully",
-      "STATUS_TEXT Version " + FAKE_APP_VERSION + " was deployed successfully",
+      String.format("LOG Started deployment of application %s version %s to %s.", FAKE_APP_NAME, FAKE_APP_VERSION, FAKE_ENV_NAME),
+      "LOG Waiting for deployment finish.",
+      String.format("PROGRESS Waiting for deployment on environment %s.", FAKE_ENV_NAME),
+      String.format("LOG Version %s was deployed to %s successfully.", FAKE_APP_VERSION, FAKE_ENV_NAME),
+      String.format("STATUS_TEXT Version %s was deployed to %s successfully.", FAKE_APP_VERSION, FAKE_ENV_NAME),
       "CLOSE " + LoggingDeploymentListener.UPDATE_ENVIRONMENT);
   }
 
   @Test
   public void deployment_progress() throws Exception {
     create().deploymentInProgress(FAKE_ENV_NAME);
-    assertLog("PROGRESS Waiting for deployment on environment " + FAKE_ENV_NAME);
+    assertLog(String.format("PROGRESS Waiting for deployment on environment %s.", FAKE_ENV_NAME));
   }
 
   @Test
   public void deployment_succeeded() throws Exception {
-    create().deploymentSucceeded(FAKE_APP_VERSION);
+    create().deploymentSucceeded(FAKE_ENV_NAME, FAKE_APP_VERSION);
     assertLog(
-      "LOG Version " + FAKE_APP_VERSION + " was deployed successfully",
-      "STATUS_TEXT Version " + FAKE_APP_VERSION + " was deployed successfully",
+      String.format("LOG Version %s was deployed to %s successfully.", FAKE_APP_VERSION, FAKE_ENV_NAME),
+      String.format("STATUS_TEXT Version %s was deployed to %s successfully.", FAKE_APP_VERSION, FAKE_ENV_NAME),
       "CLOSE " + LoggingDeploymentListener.UPDATE_ENVIRONMENT);
   }
 

--- a/aws-elasticbeanstalk-common/src/main/java/jetbrains/buildServer/runner/elasticbeanstalk/AWSClient.java
+++ b/aws-elasticbeanstalk-common/src/main/java/jetbrains/buildServer/runner/elasticbeanstalk/AWSClient.java
@@ -162,7 +162,7 @@ public class AWSClient {
     }
 
     if (isSuccess(environment, versionLabel)) {
-      myListener.deploymentSucceeded(versionLabel);
+      myListener.deploymentSucceeded(environment.getEnvironmentName(), versionLabel);
     } else {
       Listener.ErrorInfo errorEvent = hasError ? getErrorInfo(errorEvents.get(0)) : null;
       myListener.deploymentFailed(environment.getApplicationName(), environment.getEnvironmentName(), versionLabel, false, errorEvent);
@@ -258,7 +258,7 @@ public class AWSClient {
                           @NotNull Boolean hasTimeout, @Nullable ErrorInfo errorInfo) {
     }
 
-    void deploymentSucceeded(@NotNull String versionLabel) {
+    void deploymentSucceeded(@NotNull String environmentName, @NotNull String versionLabel) {
     }
 
     void exception(@NotNull AWSException exception) {


### PR DESCRIPTION
This commit adds periods to the end of each log statement to match with AWS's log output. It also outputs the environment that the application was deployed to for the final status message.

It also removes what seems to be a duplicate log line.