### PR TITLE
Decrease the amount of log spam in the build log.

### DIFF
--- a/aws-elasticbeanstalk-common/src/main/java/jetbrains/buildServer/runner/elasticbeanstalk/AWSClient.java
+++ b/aws-elasticbeanstalk-common/src/main/java/jetbrains/buildServer/runner/elasticbeanstalk/AWSClient.java
@@ -140,8 +140,6 @@ public class AWSClient {
     while (true) {
       environment = getEnvironment(environmentId);
 
-      myListener.deploymentInProgress(environment.getEnvironmentName());
-
       status = getHumanReadableStatus(environment.getStatus());
       newEvents = getNewEvents(environmentId, startDate);
 


### PR DESCRIPTION
This message end up being repeated twice in all of my logs until I removed this line. I think if we need a message saying that we are "still polling" we should do it at a verbose level. Thoughts?